### PR TITLE
fix crash due to invalid chinese game title

### DIFF
--- a/iNDS/core/iNDSGame.m
+++ b/iNDS/core/iNDSGame.m
@@ -115,8 +115,8 @@ NSString * const iNDSGameSaveStatesChangedNotification = @"iNDSGameSaveStatesCha
         
         // find preferred language
         uint32_t titleOffset = 0x240 + 0x100 * [iNDSGame preferredLanguage];
-        // version 1 doesn't have chinese, use english
-        if ((titleOffset == 0x840 && version < 2)) titleOffset = 0x340;
+        // version 1 doesn't have chinese, or chinese title is invalid, use english
+        if (titleOffset == 0x840 && (version < 2 || ((const Byte *)[iconTitleData bytes])[titleOffset] == '\0')) titleOffset = 0x340;
         
         NSData *titleData = [iconTitleData subdataWithRange:NSMakeRange(titleOffset, 0x100)];
         title = [[NSString alloc] initWithData:titleData encoding:NSUTF16LittleEndianStringEncoding];

--- a/iNDS/roms/iNDSROMTableViewController.m
+++ b/iNDS/roms/iNDSROMTableViewController.m
@@ -155,7 +155,7 @@
             // use title from ROM
             NSArray *titleLines = [game.gameTitle componentsSeparatedByString:@"\n"];
             cell.textLabel.text = titleLines[0];
-            cell.detailTextLabel.text = titleLines.count >= 1 ? titleLines[1] : nil;
+            cell.detailTextLabel.text = titleLines.count > 1 ? titleLines[1] : nil;
         } else {
             // use filename
             cell.textLabel.text = game.title;


### PR DESCRIPTION
Description added by @FrederickGeek8:
By wxdao in #18 

> "the exact code that raised unhandled index out of bound exception, crashing the app, is located here. I guess it's a typo? It should be >, not >="

> When the system language is Chinese, iNDS will look for Chinese title in the ROM, while most ROMs don't come with Chinese. And a mistake inside iNDSROMTableViewController.m will crash the app on such corrupted title data for unhandled out of bound exception.