### PR TITLE
Allow Bluetooth Routing

### DIFF
--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -350,7 +350,8 @@ enum VideoFilter : NSUInteger {
         // (Mute on && don't ignore it) or user has sound disabled
         BOOL muteSound = (muteDetector.isMute && ![defaults boolForKey:@"ignoreMute"]) || [defaults boolForKey:@"disableSound"];
         EMU_enableSound(!muteSound);
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+        AVAudioSessionCategoryOptions opts = AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:opts error:nil];
         
         // Filter
         int filterTranslate[] = {NONE, EPX, SUPEREAGLE, _2XSAI, SUPER2XSAI, BRZ2x, LQ2X, BRZ3x, HQ2X, HQ4X, BRZ4x, BRZ5x};


### PR DESCRIPTION
This pull request resolves #11 by allowing for audio to be routed through Bluetooth over A2DP. It was a quick fix, but I thought I would submit a pull request anyways.

**Some considerations**
The current implementation only supports routing over Bluetooth. To my knowledge, there is not an easy way for me to just add Airplay routing since it appears that I can only really allow for one protocol at a time (correct me if I'm wrong). Even if I could Airplay doesn't support the microphone, so more code would need to be added to check whether the microphone is disabled before routing over Airplay, etc.

**Full changelog**
- Change audio implementation to allow for Bluetooth routing over A2DP