### PR TITLE
Fix Speaker Routing

### DIFF
--- a/iNDS/Base.lproj/iNDS-Info.plist
+++ b/iNDS/Base.lproj/iNDS-Info.plist
@@ -92,7 +92,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -352,7 +352,7 @@ enum VideoFilter : NSUInteger {
         // (Mute on && don't ignore it) or user has sound disabled
         BOOL muteSound = (muteDetector.isMute && ![defaults boolForKey:@"ignoreMute"]) || [defaults boolForKey:@"disableSound"];
         EMU_enableSound(!muteSound);
-        AVAudioSessionCategoryOptions opts = AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+        AVAudioSessionCategoryOptions opts = AVAudioSessionCategoryOptionDefaultToSpeaker | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
         [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:opts error:nil];
         
         // Filter

--- a/iNDS/zh-Hans.lproj/iNDS-Info.plist
+++ b/iNDS/zh-Hans.lproj/iNDS-Info.plist
@@ -94,7 +94,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/iNDS/zh-Hant.lproj/iNDS-Info.plist
+++ b/iNDS/zh-Hant.lproj/iNDS-Info.plist
@@ -94,7 +94,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.8.0</string>
+	<string>1.8.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
Truly resolves #11 this time by making the default audio route to the internal speaker of the device, not the earpiece of the phone.  I combined Bluetooth and speaker routing, so if Bluetooth routing is unavailable, internal speaker routing will be used instead.

**Full Changelog**
- Combined Bluetooth and speaker routing
- Bumped version to 1.8.1