### PR TITLE
Fix Discard Profile Bug

### DIFF
--- a/iNDS/iNDSEmulationProfile.m
+++ b/iNDS/iNDSEmulationProfile.m
@@ -326,9 +326,9 @@ static CGFloat const OffsetYForTriggerOniPhoneX = 130.f;
             view.layer.borderWidth = 0;
         }
     }
+
     [self removeSnapLines];
     [self deselectView];
-    self.sizeSlider.hidden = YES;
 }
 
 -(NSArray *) editableViews

--- a/iNDS/iNDSProfileEditorTableViewController.m
+++ b/iNDS/iNDSProfileEditorTableViewController.m
@@ -98,11 +98,20 @@
             inEditingMode = NO;
         } else { //Discard
             //Just reload from file
-            NSString * profilePath = [iNDSEmulationProfile pathForProfileName:currentProfile.name];
-            iNDSEmulationProfile * reloadedProfile = [iNDSEmulationProfile profileWithPath:profilePath];
-            [emulationController loadProfile:reloadedProfile];
+            iNDSEmulationProfile *reloadedProfile;
+            if ([currentProfile.name isEqualToString:@"iNDSDefaultProfile"]) {
+                reloadedProfile = [[iNDSEmulationProfile alloc] initWithProfileName:@"iNDSDefaultProfile"];
+            } else {
+                NSString * profilePath = [iNDSEmulationProfile pathForProfileName:currentProfile.name];
+                reloadedProfile = [iNDSEmulationProfile profileWithPath:profilePath];
+            }
+            
             inEditingMode = NO;
             [emulationController exitEditMode];
+            [emulationController loadProfile:reloadedProfile];
+            [emulationController.profile ajustLayout];
+            
+            
             [self.navigationController popViewControllerAnimated:YES];
         }
         


### PR DESCRIPTION
**Issue**
This pull request resolves the layout bug describes in issue #31. When the "Default" layout profile was selected and the user was editing the layout of the page, if the user were to discard the changes made to the "Default" profile, the profile editor interface would persist on screen and the changes made to the profile would not be discarded.

**Resolution**
This issue was caused since the Default profile is not one that is saved to disk by iNDS, but rather one that is hard-coded into the program. Thus, when the changes are discarded, iNDS attempts to load the original from the disk but fails, leaving the changes on screen. This is resolves by first checking if the "Default" profile is selected and loading it if that is the case.

**Full Changelog**
- Added check for "Default" profile selection.