### PR TITLE
Bug Roundup

### DIFF
--- a/iNDS.xcodeproj/xcshareddata/xcschemes/iNDS.xcscheme
+++ b/iNDS.xcodeproj/xcshareddata/xcschemes/iNDS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D1472A4FC467EB132BFC5E4616B26273"
+               BlueprintIdentifier = "AB2792E7FD8EB866A7C0E48DB46045CB"
                BuildableName = "libPods-iNDS.a"
                BlueprintName = "Pods-iNDS"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E419D9020BB55800B1A1519B7032D0BB"
+               BlueprintIdentifier = "EACF0F9E35C68E5203526AE65A263683"
                BuildableName = "libUnrarKit.a"
                BlueprintName = "UnrarKit"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/iNDS/core/emu.cpp
+++ b/iNDS/core/emu.cpp
@@ -184,7 +184,7 @@ void EMU_init(int lang)
 
 void EMU_loadSettings()
 {
-    CommonSettings.num_cores = sysconf( _SC_NPROCESSORS_ONLN );
+    CommonSettings.num_cores = (int) sysconf( _SC_NPROCESSORS_ONLN );
 	LOGI("%i cores detected", CommonSettings.num_cores);
 	CommonSettings.advanced_timing = false;
 	CommonSettings.cheatsDisable = false;
@@ -300,6 +300,14 @@ void EMU_setSynchMode(bool enabled)
 
 void EMU_enableSound(bool enabled)
 {
+/*
+ SPU seems to need to be kickstarted. If left disabled when initializing the ROM,
+ then we can't expect to magically enable it partway through. To solve this, we
+ just let it run for a cycle if we disable sound.
+ 
+ More information see iNDS-Team/iNDS#35
+ */
+    if (!enabled) SPU_Emulate_user(true);
     soundEnabled = enabled;
 }
 

--- a/iNDS/core/sndcoreaudio.mm
+++ b/iNDS/core/sndcoreaudio.mm
@@ -115,13 +115,18 @@ u32 SNDCoreAudioGetAudioSpace() {
 }
 
 void SNDCoreAudioMuteAudio() {
-    AudioQueueStop(audioQueue, false);
+    AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, 0.0);
 }
 
 void SNDCoreAudioUnMuteAudio() {
-    AudioQueueStart(audioQueue, NULL);
+    AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, 1.0);
 }
 
 void SNDCoreAudioSetVolume(int volume) {
-    
+    /*
+     This function was not implemented, but if it was implemented,
+     this is how to do it.
+    float scaled = volume / 100.0;
+    AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, scaled);
+     */
 }

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -268,6 +268,7 @@ enum VideoFilter : NSUInteger {
     disableTouchScreen = [[NSUserDefaults standardUserDefaults] boolForKey:@"disableTouchScreen"];
     
     coreLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(emulatorLoop)];
+    coreLink.preferredFramesPerSecond = 60;
     coreLink.paused = YES;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
         [coreLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];


### PR DESCRIPTION
This pull requests resolves #35, fixes #33, and closes #36. In doing so, the bug in which the game audio would be disabled after switching games as been resolved and the bug in which game audio would be disabled after toggling `Synchronous Audio` has been fixed. Additionally, games will now throttle to the native 60 fps instead of running as fast as possible.

**Full Changelog**
- SPU is now "kickstarted" upon launching a ROM
- Audio is now muted instead of stopped when the menu is visible
- Games are throttled to 60 fps