### PR TITLE
Double buffer screen rendering

### DIFF
--- a/iNDS/core/emu.cpp
+++ b/iNDS/core/emu.cpp
@@ -459,16 +459,7 @@ u32 *EMU_RBGA8Buffer()
 
 void EMU_copyMasterBuffer()
 {
-    video.srcBuffer = GPU_screen;
-    
-    //convert pixel format to 32bpp for compositing
-    //why do we do this over and over? well, we are compositing to
-    //filteredbuffer32bpp, and it needs to get refreshed each frame..
-    const int size = video.size();
-    u16* src = (u16*)video.srcBuffer;
-    u32* dest = video.buffer;
-    for(int i=0;i<size;++i)
-        *dest++ = 0xFF000000 | RGB15TO32_NOALPHA(src[i]);
+    video.copyBuffer(GPU_screen);
 }
 
 void EMU_touchScreenTouch(int x, int y)

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -684,15 +684,14 @@ NSInteger filter = [[NSUserDefaults standardUserDefaults] integerForKey:@"videoF
     
     if (!EMU_frameSkip(false)) {
         [self calculateFPS:1];
+        EMU_copyMasterBuffer();
         if (filter == -1) {
-            EMU_copyMasterBuffer();
             [self updateDisplay];
         } else {
             // Run the filter on a seperate thread to increase performance
             // Core will always be one frame ahead
             dispatch_semaphore_wait(displaySemaphore, DISPATCH_TIME_FOREVER);
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                EMU_copyMasterBuffer();
                 //This will automatically throttle fps to 60
                 [self updateDisplay];
                 dispatch_semaphore_signal(displaySemaphore);


### PR DESCRIPTION
When using a filter the GPU screen buffer was blitted in parallel with
the emulator loop, causing flickering where the screen was updated.
Instead, blit to one buffer and swap the buffer before applying the
filter and rendering the image.

Fixes #56.