### PR TITLE
Add support for URL Scheme ROM launching

### DIFF
--- a/iNDS/AppDelegate.h
+++ b/iNDS/AppDelegate.h
@@ -41,6 +41,8 @@
 
 - (BOOL)isSystemApplication;
 
+extern NSString * const iNDSUserRequestedToPlayROMNotification;
+
 @end
 
 

--- a/iNDS/AppDelegate.m
+++ b/iNDS/AppDelegate.m
@@ -42,6 +42,8 @@
 
 @end
 
+NSString * const iNDSUserRequestedToPlayROMNotification = @"iNDSUserRequestedToPlayROMNotification";
+
 @implementation AppDelegate
 
 + (AppDelegate*)sharedInstance
@@ -157,7 +159,7 @@
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
     NSLog(@"Opening: %@", url);
-    if ([[[NSString stringWithFormat:@"%@", url] substringToIndex:2] isEqualToString: @"db"]) {
+    if ([[url scheme] hasPrefix:@"db"]) {
         NSLog(@"DB");
         //        if ([[DBSession sharedSession] handleOpenURL:url]) {
         //            if ([[DBSession sharedSession] isLinked]) {
@@ -179,6 +181,20 @@
         //            }
         return YES;
         //        }
+    } else if ([[[url scheme] lowercaseString] isEqualToString:@"inds"]) {
+        NSString *name = [[url host] stringByRemovingPercentEncoding];
+        
+        iNDSGame *rom = [iNDSGame gameWithName:name];
+        
+        if (rom) {
+            NSLog(@"Found ROM");
+            [[NSNotificationCenter defaultCenter] postNotificationName:iNDSUserRequestedToPlayROMNotification object:rom userInfo:nil];
+            return YES;
+        } else {
+            NSLog(@"Could not find ROM");
+        }
+        
+        return NO;
     } else if (url.isFileURL && [[NSFileManager defaultManager] fileExistsAtPath:url.path]) {
         NSLog(@"Zip File (maybe)");
         NSFileManager *fm = [NSFileManager defaultManager];

--- a/iNDS/Base.lproj/iNDS-Info.plist
+++ b/iNDS/Base.lproj/iNDS-Info.plist
@@ -109,9 +109,19 @@
 				<string>db-ks1ulr086qvvy1k</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>net.nerd.iNDS</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>iNDS</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>65</string>
+	<string>66</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>dbapi-8-emm</string>

--- a/iNDS/core/iNDSGame.h
+++ b/iNDS/core/iNDSGame.h
@@ -26,6 +26,7 @@ FOUNDATION_EXPORT NSString * const iNDSGameSaveStatesChangedNotification;
 + (int)preferredLanguage; // returns a NDS_FW_LANG_ constant
 + (NSArray*)gamesAtPath:(NSString*)path saveStateDirectoryPath:(NSString*)saveStatePath;
 + (iNDSGame*)gameWithPath:(NSString*)path saveStateDirectoryPath:(NSString*)saveStatePath;
++ (iNDSGame*)gameWithName:(NSString *)name;
 - (iNDSGame*)initWithPath:(NSString*)path saveStateDirectoryPath:(NSString*)saveStatePath;
 - (NSString*)pathForSaveStateWithName:(NSString*)name;
 - (NSString*)pathForSaveStateAtIndex:(NSInteger)idx;

--- a/iNDS/core/iNDSGame.m
+++ b/iNDS/core/iNDSGame.m
@@ -9,6 +9,7 @@
 #import "iNDSGame.h"
 #import <FileMD5Hash/FileHash.h>
 #import "iNDSDBManager.h"
+#import "AppDelegate.h"
 
 NSString * const iNDSGameSaveStatesChangedNotification = @"iNDSGameSaveStatesChangedNotification";
 
@@ -40,6 +41,10 @@ NSString * const iNDSGameSaveStatesChangedNotification = @"iNDSGameSaveStatesCha
 + (iNDSGame*)gameWithPath:(NSString*)path saveStateDirectoryPath:(NSString*)saveStatePath
 {
     return [[iNDSGame alloc] initWithPath:path saveStateDirectoryPath:saveStatePath];
+}
+
++ (iNDSGame*)gameWithName:(NSString *)name {
+    return [[iNDSGame alloc] initWithPath:[[AppDelegate.sharedInstance.documentsPath stringByAppendingPathComponent:name] stringByAppendingPathExtension:@"nds"] saveStateDirectoryPath:AppDelegate.sharedInstance.batteryDir];
 }
 
 - (iNDSGame*)initWithPath:(NSString*)path saveStateDirectoryPath:(NSString*)saveStatePath

--- a/iNDS/emulator/iNDSEmulatorViewController.h
+++ b/iNDS/emulator/iNDSEmulatorViewController.h
@@ -33,4 +33,5 @@
 - (void)newSaveState;
 - (void)reloadEmulator;
 - (void)setLidClosed:(BOOL)closed;
+- (void) userRequestedToPlayROM:(NSNotification *) notification;
 @end

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -200,7 +200,8 @@ enum VideoFilter : NSUInteger {
     [notificationCenter addObserver:self selector:@selector(screenChanged:) name:UIScreenDidDisconnectNotification object:nil];
     [notificationCenter addObserver:self selector:@selector(controllerActivated:) name:GCControllerDidConnectNotification object:nil];
     [notificationCenter addObserver:self selector:@selector(controllerDeactivated:) name:GCControllerDidDisconnectNotification object:nil];
-    
+    [notificationCenter addObserver:self selector:@selector(userRequestedToPlayROM:) name:iNDSUserRequestedToPlayROMNotification object:nil];
+
     if ([[GCController controllers] count] > 0) {
         [self controllerActivated:nil];
     }
@@ -303,6 +304,33 @@ enum VideoFilter : NSUInteger {
         [self.profile ajustLayout];
         [self toggleSettings:self];
     });
+}
+
+- (void) userRequestedToPlayROM:(NSNotification *) notification {
+    NSLog(@"Notification");
+    iNDSGame *game = notification.object;
+    
+    if ([self.game isEqual:game]) {
+        return;
+    }
+    
+    if (self.game == nil) {
+        [AppDelegate.sharedInstance startGame:game withSavedState:-1];
+    }
+    
+    [self pauseEmulation];
+    
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Game Currently Running" message:[NSString stringWithFormat:@"Would you like to end %@ and start %@? All unsaved data will be lost.", self.game.title, game.title] preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+        [self resumeEmulation];
+    }];
+    UIAlertAction *continueAction = [UIAlertAction actionWithTitle:@"Continue" style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
+        [self changeGame:game];
+    }];
+    
+    [alert addAction:cancelAction];
+    [alert addAction:continueAction];
+    
 }
 
 - (void)didReceiveMemoryWarning

--- a/iNDS/roms/iNDSROMTableViewController.h
+++ b/iNDS/roms/iNDSROMTableViewController.h
@@ -16,5 +16,6 @@
 }
 
 - (void)reloadGames:(id)sender;
+- (void) userRequestedToPlayROM:(NSNotification *) notification;
 
 @end

--- a/iNDS/roms/iNDSROMTableViewController.m
+++ b/iNDS/roms/iNDSROMTableViewController.m
@@ -57,6 +57,7 @@
     [SDWebImageManager sharedManager].delegate = self;
     
     [self prefetchImages];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(userRequestedToPlayROM:) name:iNDSUserRequestedToPlayROMNotification object:nil];
 }
 
 - (void)didReceiveMemoryWarning
@@ -294,6 +295,14 @@
     return newImage;
 }
 
+#pragma mark - Start Game from URL
+
+- (void) userRequestedToPlayROM:(NSNotification *) notification {
+    iNDSGame *game = notification.object;
+    
+    [AppDelegate.sharedInstance startGame:game withSavedState:-1];
+
+}
 
 @end
 


### PR DESCRIPTION
This issue fixes #81 and in doing so, allows for launching of games via the `inds://<filename>` scheme. This can be integrated into Siri Shortcuts so that games can be launched via Siri.