### PR TITLE
Fix compilation error in CHBgDropboxSync-master

### DIFF
--- a/iNDS/CHBgDropboxSync-master/CHBgDropboxSync.m
+++ b/iNDS/CHBgDropboxSync-master/CHBgDropboxSync.m
@@ -285,7 +285,7 @@ CHBgDropboxSync* bgDropboxSyncInstance=nil;
 - (void)startTaskRemoteDelete:(NSString*)file {
     NSLog(@"Sync: Deleting remote file %@", file);
     [deletedFiles addObject:file];
-    [[client.filesRoutes delete_V2:$str(@"/%@", file)] setResponseBlock:^(DBFILESMetadata * _Nullable result, DBFILESDeleteError * _Nullable routeError, DBRequestError * _Nullable networkError) {
+    [[client.filesRoutes delete_V2:$str(@"/%@", file)] setResponseBlock:^(DBFILESDeleteResult * _Nullable result, DBFILESDeleteError * _Nullable routeError, DBRequestError * _Nullable networkError) {
         if (result) {
             [self stepComplete];
         } else {


### PR DESCRIPTION
Fixes #172 and #178. Pulled fresh from my repo and was able to compile it first try using the instructions in the docs.

It appears that an argument type of the block was incorrect -- I just changed it to the correct type as discussed in #172.