### PR TITLE
Add audio output volume control

### DIFF
--- a/iNDS/AppDelegate.m
+++ b/iNDS/AppDelegate.m
@@ -596,7 +596,9 @@ NSString * const iNDSUserRequestedToPlayROMNotification = @"iNDSUserRequestedToP
         
         // Audio
         WCEasySettingsSection *audioSection = [[WCEasySettingsSection alloc] initWithTitle:@"Audio" subTitle:@""];
-        audioSection.items = @[[[WCEasySettingsSwitch alloc] initWithIdentifier:@"disableSound"
+        audioSection.items = @[[[WCEasySettingsSlider alloc] initWithIdentifier:@"outputVolume"
+                                                                          title:@"Output Volume"],
+                               [[WCEasySettingsSwitch alloc] initWithIdentifier:@"disableSound"
                                                                           title:@"Disable Sound"],
                                [[WCEasySettingsSwitch alloc] initWithIdentifier:@"allowExternalAudio"
                                                                           title:@"Allow External Audio"],

--- a/iNDS/core/emu.cpp
+++ b/iNDS/core/emu.cpp
@@ -309,6 +309,12 @@ void EMU_enableSound(bool enabled)
     soundEnabled = enabled;
 }
 
+void EMU_setAudioOutputVolume(double volume)
+{
+    int vol = volume * 100;
+    SPU_SetVolume(vol);
+}
+
 void EMU_setFrameSkip(int skip)
 {
     if (skip == -1) {

--- a/iNDS/core/emu.cpp
+++ b/iNDS/core/emu.cpp
@@ -301,11 +301,11 @@ void EMU_enableSound(bool enabled)
 /*
  SPU seems to need to be kickstarted. If left disabled when initializing the ROM,
  then we can't expect to magically enable it partway through. To solve this, we
- just let it run for a cycle if we disable sound.
+ just let it run for a cycle if we disable sound. We only kick the SPU when soundEnabled has changed, to prevent unnecessarily kickstarting the SPU.
  
  More information see iNDS-Team/iNDS#35
  */
-    if (!enabled) SPU_Emulate_user(true);
+    if(!enabled && soundEnabled != enabled) SPU_Emulate_user(true);
     soundEnabled = enabled;
 }
 

--- a/iNDS/core/emu.h
+++ b/iNDS/core/emu.h
@@ -37,6 +37,7 @@ bool EMU_doRomLoad(const char* path, const char* logical);
 bool EMU_loadRom(const char* path);
 void EMU_change3D(int type);
 void EMU_changeSound(int type);
+void EMU_setAudioOutputVolume(double volume);
 void EMU_enableSound(bool enable);
 bool EMU_frameSkip(bool force);
 void EMU_setFrameSkip(int skip);

--- a/iNDS/core/sndcoreaudio.mm
+++ b/iNDS/core/sndcoreaudio.mm
@@ -41,6 +41,7 @@ static s16 *sndBuffer[NUM_BUFFERS];
 static bool audioQueueStarted = false;
 static AudioQueueBufferRef aqBuffer[NUM_BUFFERS];
 static AudioQueueRef audioQueue;
+static float volume = 1.0;
 
 void SNDCoreAudioCallback(void *data, AudioQueueRef mQueue, AudioQueueBufferRef mBuffer) {
     mBuffer->mAudioDataByteSize = sndBufferSize;
@@ -119,14 +120,11 @@ void SNDCoreAudioMuteAudio() {
 }
 
 void SNDCoreAudioUnMuteAudio() {
-    AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, 1.0);
+    AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, volume);
 }
 
 void SNDCoreAudioSetVolume(int volume) {
-    /*
-     This function was not implemented, but if it was implemented,
-     this is how to do it.
     float scaled = volume / 100.0;
+    ::volume = scaled;
     AudioQueueSetParameter(audioQueue, kAudioQueueParam_Volume, scaled);
-     */
 }

--- a/iNDS/iNDSEmulatorViewController.mm
+++ b/iNDS/iNDSEmulatorViewController.mm
@@ -373,6 +373,10 @@ enum VideoFilter : NSUInteger {
         // (Mute on && don't ignore it) or user has sound disabled
         BOOL muteSound = [defaults boolForKey:@"disableSound"];
         EMU_enableSound(!muteSound);
+        
+        double outputVolume = [defaults doubleForKey:@"outputVolume"];
+        EMU_setAudioOutputVolume(outputVolume);
+        
         AVAudioSessionCategoryOptions opts = AVAudioSessionCategoryOptionDefaultToSpeaker | AVAudioSessionCategoryOptionAllowBluetoothA2DP;
         if([defaults boolForKey:@"allowExternalAudio"]){
             opts |= AVAudioSessionCategoryOptionMixWithOthers;

--- a/iNDS/settings/Defaults.plist
+++ b/iNDS/settings/Defaults.plist
@@ -16,6 +16,8 @@
 	<true/>
 	<key>frameSkip</key>
 	<integer>-1</integer>
+	<key>outputVolume</key>
+	<integer>1</integer>
 	<key>disableSound</key>
 	<false/>
 	<key>allowExternalAudio</key>


### PR DESCRIPTION
Adds a "Output Volume" slider Audio section in Emulator Settings.

Previously, there was no way to control the game’s volume, apart from the system level audio controls. This was mainly an issue when using the “Allow External Audio” setting. When mixing external audio and game audio, both were at full volume. Having control over the game volume makes for a better experience when mixing with external audio. It allows for having game audio quieter in the “background” while having music/podcasts/etc louder in the “foreground”.